### PR TITLE
Fix for projects that are located not in the root git directory

### DIFF
--- a/Sources/typokana/FileUtil.swift
+++ b/Sources/typokana/FileUtil.swift
@@ -19,6 +19,13 @@ func visitFiles(in root: AbsolutePath, onFind: (AbsolutePath) throws -> Void) re
     }
 }
 
+func getGitRoot() throws -> String {
+    let process = Process(args: "git", "rev-parse", "--show-toplevel")
+    try process.launch()
+    let result = try process.waitUntilExit()
+    return try result.utf8Output().trimmingCharacters(in: .newlines)
+}
+
 func extractModifiedFiles() throws -> [String] {
     let processOfGitDiff = Process(args: "git", "diff", "--diff-filter=d", "--name-only", "HEAD")
     try processOfGitDiff.launch()

--- a/Sources/typokana/main.swift
+++ b/Sources/typokana/main.swift
@@ -40,8 +40,9 @@ do {
     let shouldCheckDiffOnly = result.get(optionForDiffOnly) ?? false
     let targetFiles: [AbsolutePath] = try {
         if shouldCheckDiffOnly {
+            let gitRoot = AbsolutePath(try getGitRoot())
             return try extractModifiedFiles().compactMap { path in
-                let formattedPath = AbsolutePath(path, relativeTo: cwd)
+                let formattedPath = AbsolutePath(path, relativeTo: gitRoot)
                 guard formattedPath.extension == "swift" else { return nil }
                 return formattedPath
             }


### PR DESCRIPTION
Fixed https://github.com/ezura/spell-checker-for-swift/issues/23